### PR TITLE
Remove Maps API Key from dialog

### DIFF
--- a/GridMaps/GridMaps/Config/editor.json
+++ b/GridMaps/GridMaps/Config/editor.json
@@ -1,15 +1,16 @@
 {
-	"name": "GridMaps",
-	"alias": "gridMaps",
-	"view": "/App_Plugins/GridMaps/Views/gridmapsgrideditor.html",
-	"render": "/App_Plugins/GridMaps/Render/GridMapsGridEditor.cshtml",
-	"icon": "icon-location-nearby",
-    "config": {
-        "defaultLat": 50.1109221,
-        "defaultLng": 8.682126700000026,
-        "defaultZoom": 6,
-		"defaultMapType": "ROADMAP",
-		"defaultHeight": 400,
-		"showAsStreetView": false
-    }
+  "name": "GridMaps",
+  "alias": "gridMaps",
+  "view": "/App_Plugins/GridMaps/Views/gridmapsgrideditor.html",
+  "render": "/App_Plugins/GridMaps/Render/GridMapsGridEditor.cshtml",
+  "icon": "icon-location-nearby",
+  "config": {
+    "defaultLat": 50.1109221,
+    "defaultLng": 8.682126700000026,
+    "defaultZoom": 6,
+    "defaultMapType": "ROADMAP",
+    "defaultHeight": 400,
+    "defaultApiKey":  "your-api-key-here",
+    "showAsStreetView": false
+  }
 }

--- a/GridMaps/GridMaps/Js/gridmaps.controllers.js
+++ b/GridMaps/GridMaps/Js/gridmaps.controllers.js
@@ -47,7 +47,7 @@ function ($scope, $rootScope, $timeout, $routeParams, assetsService, notificatio
             mapType: $scope.control.editor.config.defaultMapType,
             height: $scope.control.editor.config.defaultHeight,
             streetView: $scope.control.editor.config.showAsStreetView,
-            apiKey: ''
+            apiKey: $scope.control.editor.config.defaultApiKey,
         });
 
         $timeout(function () {

--- a/GridMaps/GridMaps/Views/gridmapsgrideditor.dialog.html
+++ b/GridMaps/GridMaps/Views/gridmapsgrideditor.dialog.html
@@ -1,7 +1,7 @@
 ﻿<form name="gmgeForm" novalidate class="gmge-dialog umb-panel" ng-controller="GridMapsEditorDialogController">
-    
+
     <div class="umb-panel-body no-header with-footer umb-scrollable" ng-switch="dialogMode">
-        
+
         <umb-control-group label="Choose a map type">
             <select name="map-type" ng-model="dialogData.mapType" required>
                 <option>ROADMAP</option>
@@ -23,23 +23,19 @@
             <input type="checkbox" name="streetview" ng-model="dialogData.streetView" />
         </umb-control-group>
 
-        <umb-control-group label="Maps API Key">
-            <input type="text" name="apikey" ng-model="dialogData.apiKey" />
-        </umb-control-group>
-
     </div>
 
     <div class="umb-panel-footer">
         <div class="umb-el-wrap umb-panel-buttons">
             <div class="btn-toolbar umb-btn-toolbar">
-                
-                <a href ng-click="close()" class="btn btn-link">
-	        		<localize key="general_cancel">Cancel</localize>
-				</a>
 
-				<button class="btn btn-primary" ng-click="save()">
-				    <localize key="buttons_save">Save</localize>
-				</button>
+                <a href ng-click="close()" class="btn btn-link">
+                    <localize key="general_cancel">Cancel</localize>
+                </a>
+
+                <button class="btn btn-primary" ng-click="save()">
+                    <localize key="buttons_save">Save</localize>
+                </button>
 
             </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # GridMaps
 GridMaps Grid Editor for Umbraco
 
+__Installation__
+
+Install the package and add the Google Maps script to your master layout..
+
+    <script async defer src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=YOUR_KEY"></script>
+
 __Settings__
 
 Remember to update the settings in `~/config/grid.editors.config.js"`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # GridMaps
 GridMaps Grid Editor for Umbraco
+
+__Settings__
+
+Remember to update the settings in `~/config/grid.editors.config.js"`
+
+You will need to set the `defaultApiKey` to a Google Maps API Key. [Google - Get API Key](https://developers.google.com/maps/documentation/javascript/get-api-key)


### PR DESCRIPTION
Moved `ApiKey` to grid.editors.config.js 

E.g. "defaultApiKey":  "your-api-key-here".